### PR TITLE
Add MP3 decoder and hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ convert type sourceFile [targetFile]<br/>
 <br/>
   Example: convert tx2txt 0500000B.tx "Azziz's Temple.txt"<br/>
   will convert 0500000B.tx to Azziz's Temple.txt<br/>
+
+## Color mode fix
+
+If the game throws a DirectDraw error when running windowed with the `-W` switch,
+in compatibility settings for the game executable check "Reduced color mode"
+and select 16-bit.

--- a/Septerra.AudioConverter/Decoder.hpp
+++ b/Septerra.AudioConverter/Decoder.hpp
@@ -1,0 +1,484 @@
+#pragma once
+
+#include "Windows.h"
+
+#define LOBYTE(x)   (*((BYTE*)&(x)))   // low byte
+#define LOWORD(x)   (*((WORD*)&(x)))   // low word
+#define HIBYTE(x)   (*((BYTE*)&(x)+1))
+#define HIWORD(x)   (*((WORD*)&(x)+1))
+
+#define _BYTE BYTE
+#define _WORD WORD
+#define _DWORD DWORD
+
+const char g_AudDecodeData1[] =
+{
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0x02, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	0x02, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00
+};
+
+const char g_AudDecodeData2_Backing[] =
+{
+	0x07, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00,
+	0x0B, 0x00, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x00, 0x0D, 0x00, 0x00, 0x00, 0x0E, 0x00, 0x00, 0x00,
+	0x10, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x15, 0x00, 0x00, 0x00,
+	0x17, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 0x1C, 0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00,
+	0x22, 0x00, 0x00, 0x00, 0x25, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00, 0x00, 0x2D, 0x00, 0x00, 0x00,
+	0x32, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x3C, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00,
+	0x49, 0x00, 0x00, 0x00, 0x50, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00,
+	0x6B, 0x00, 0x00, 0x00, 0x76, 0x00, 0x00, 0x00, 0x82, 0x00, 0x00, 0x00, 0x8F, 0x00, 0x00, 0x00,
+	0x9D, 0x00, 0x00, 0x00, 0xAD, 0x00, 0x00, 0x00, 0xBE, 0x00, 0x00, 0x00, 0xD1, 0x00, 0x00, 0x00,
+	0xE6, 0x00, 0x00, 0x00, 0xFD, 0x00, 0x00, 0x00, 0x17, 0x01, 0x00, 0x00, 0x33, 0x01, 0x00, 0x00,
+	0x51, 0x01, 0x00, 0x00, 0x73, 0x01, 0x00, 0x00, 0x98, 0x01, 0x00, 0x00, 0xC1, 0x01, 0x00, 0x00,
+	0xEE, 0x01, 0x00, 0x00, 0x20, 0x02, 0x00, 0x00, 0x56, 0x02, 0x00, 0x00, 0x92, 0x02, 0x00, 0x00,
+	0xD4, 0x02, 0x00, 0x00, 0x1C, 0x03, 0x00, 0x00, 0x6C, 0x03, 0x00, 0x00, 0xC3, 0x03, 0x00, 0x00,
+	0x24, 0x04, 0x00, 0x00, 0x8E, 0x04, 0x00, 0x00, 0x02, 0x05, 0x00, 0x00, 0x83, 0x05, 0x00, 0x00,
+	0x10, 0x06, 0x00, 0x00, 0xAB, 0x06, 0x00, 0x00, 0x56, 0x07, 0x00, 0x00, 0x12, 0x08, 0x00, 0x00,
+	0xE0, 0x08, 0x00, 0x00, 0xC3, 0x09, 0x00, 0x00, 0xBD, 0x0A, 0x00, 0x00, 0xD0, 0x0B, 0x00, 0x00,
+	0xFF, 0x0C, 0x00, 0x00, 0x4C, 0x0E, 0x00, 0x00, 0xBA, 0x0F, 0x00, 0x00, 0x4C, 0x11, 0x00, 0x00,
+	0x07, 0x13, 0x00, 0x00, 0xEE, 0x14, 0x00, 0x00, 0x06, 0x17, 0x00, 0x00, 0x54, 0x19, 0x00, 0x00,
+	0xDC, 0x1B, 0x00, 0x00, 0xA5, 0x1E, 0x00, 0x00, 0xB6, 0x21, 0x00, 0x00, 0x15, 0x25, 0x00, 0x00,
+	0xCA, 0x28, 0x00, 0x00, 0xDF, 0x2C, 0x00, 0x00, 0x5B, 0x31, 0x00, 0x00, 0x4B, 0x36, 0x00, 0x00,
+	0xB9, 0x3B, 0x00, 0x00, 0xB2, 0x41, 0x00, 0x00, 0x44, 0x48, 0x00, 0x00, 0x7E, 0x4F, 0x00, 0x00,
+	0x71, 0x57, 0x00, 0x00, 0x2F, 0x60, 0x00, 0x00, 0xCE, 0x69, 0x00, 0x00, 0x62, 0x74, 0x00, 0x00,
+	0xFF, 0x7F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+const short* g_AudDecodeData2 = (const short*)g_AudDecodeData2_Backing;
+
+struct Mp3Header
+{
+	uint16_t Type;
+	uint16_t Unknown;
+	uint32_t SampleCount;
+	uint16_t SampleRate;
+	uint8_t BitDepth;
+	uint8_t ChannelCount;
+};
+
+/* 194 */
+struct __declspec(align(2)) struct_v12
+{
+	uint8_t gap0[16];
+	uint16_t SampleRate;
+	uint8_t Channels;
+	uint8_t BitDepth;
+};
+
+/* 201 */
+struct __declspec(align(4)) source_info
+{
+	source_info* unk;
+	uint32_t DbRecIdx;
+	uint32_t TotalPcmLen;
+	uint32_t Pcm;
+	uint32_t field_10;
+	char field_14;
+	char field_15;
+	char field_16;
+	char field_17;
+	char field_18;
+	char field_19;
+	char field_1A;
+	char field_1B;
+	char field_1C;
+	char field_1D;
+	char field_1E;
+	char field_1F;
+	char field_20;
+	char field_21;
+	char field_22;
+	char field_23;
+	char field_24;
+	char field_25;
+	char field_26;
+	char field_27;
+	char field_28;
+	char field_29;
+	char field_2A;
+	char field_2B;
+	uint32_t DataLen;
+	uint32_t Format;
+	uint32_t field_34;
+	short SampleRate;
+	uint8_t ChannelCount;
+	uint8_t BitDepth;
+	char field_3C;
+	__declspec(align(4)) char field_40;
+	uint32_t IsPCM;
+	char field_48;
+	__declspec(align(4)) char field_4C;
+	__declspec(align(4)) char field_50;
+};
+
+/* 202 */
+struct __declspec(align(4)) struct_v4
+{
+	uint32_t* pdword0;
+	uint32_t* pdword4;
+	uint32_t dword8;
+	uint32_t WParam;
+	uint32_t LParam;
+	uint32_t dword14;
+};
+
+/* 192 */
+struct __declspec(align(4)) sound
+{
+	sound* next;
+	struct_v12* dword4;
+	uint32_t dword8;
+	source_info* SourceInfo;
+	uint32_t dword10;
+	unsigned char* Mp3ReadBuf;
+	uint32_t Mp3PlayedLen;
+	uint32_t field_1C;
+	char* Pcm;
+	uint32_t PcmLen;
+	uint32_t PcmPlayedLen;
+	uint32_t RawPlayedLen;
+	uint32_t field_30;
+	uint32_t PcmLenLeft;
+	uint32_t field_38;
+	uint32_t field_3C;
+	uint32_t dword40;
+	uint8_t gap44[4];
+	void* DSBuf;
+	uint8_t gap4C[4];
+	uint32_t BufBytes;
+	uint32_t dword54;
+	uint32_t dword58;
+	uint8_t gap5C[8];
+	uint32_t dword64;
+	struct_v4* PStructV4;
+	uint32_t State;
+	uint32_t field_70;
+	char field_74;
+	char field_75;
+	uint16_t field_76;
+	uint32_t dword78;
+};
+
+/**
+ * Jump cases other than 0x11 and 0x12 are removed;
+ * they are never called (we only have 16-bit mono and stereo MP3s)
+ */
+void Decode(sound* aud, char* out, uint32_t lenNeeded2, char* input)
+{
+	sound* result; // eax
+	source_info* mp3Info; // ecx
+	DWORD pcmLen; // edi
+	byte* pcm2; // ebx
+	unsigned int lenNeeded; // esi
+	unsigned int playedLen; // edx
+	DWORD mp3PlayedLen; // ecx
+	unsigned int lenToCpy; // ecx
+	size_t lenToRead; // esi
+	int secondOrFourthByte; // edx
+	int firstShort2; // ecx
+	char fifthByte; // al
+	_BYTE* mp3ByteCur; // esi
+	_WORD* v18; // edi
+	int v19; // eax
+	int v20; // eax
+	int v21; // eax
+	bool v22; // sf
+	char v23; // al
+	_WORD* v24; // edi
+	int v25; // eax
+	int v26; // eax
+	int v27; // eax
+	char v28; // al
+	_WORD* v29 = nullptr; // edi
+	unsigned __int16 v30; // cx
+	int v31; // eax
+	int v32; // eax
+	int v33; // eax
+	char v34; // al
+	_WORD* v35; // edi
+	int v36; // eax
+	int v37; // eax
+	int v38; // eax
+	size_t readedLen; // [esp+Ch] [ebp-4Ch]
+	unsigned __int16 v52; // [esp+18h] [ebp-40h]
+	unsigned __int16 v53; // [esp+18h] [ebp-40h]
+	unsigned int mp3DataLen; // [esp+20h] [ebp-38h]
+	DWORD playedLen2; // [esp+2Ch] [ebp-2Ch]
+	unsigned __int8 channelCount; // [esp+30h] [ebp-28h]
+	DWORD dbRecordIndex; // [esp+34h] [ebp-24h]
+	unsigned __int8 bitDepth; // [esp+38h] [ebp-20h]
+	int dstCur; // [esp+3Ch] [ebp-1Ch]
+	signed int pcmShortCura; // [esp+40h] [ebp-18h]
+	signed int pcmShortCurb; // [esp+40h] [ebp-18h]
+	DWORD mp3PlayedLen2; // [esp+44h] [ebp-14h]
+	char v68; // [esp+48h] [ebp-10h]
+	char v69; // [esp+48h] [ebp-10h]
+	char v70; // [esp+48h] [ebp-10h]
+	char v71; // [esp+48h] [ebp-10h]
+	size_t secondShort; // [esp+4Ch] [ebp-Ch]
+	int firstShort; // [esp+50h] [ebp-8h]
+	unsigned __int8 sixthByte; // [esp+56h] [ebp-2h]
+	char v77; // [esp+57h] [ebp-1h]
+
+	result = aud;
+	mp3Info = aud->SourceInfo;
+	lenNeeded = lenNeeded2;
+	channelCount = mp3Info->ChannelCount;
+	dstCur = 0;
+	bitDepth = mp3Info->BitDepth;
+	mp3DataLen = mp3Info->DataLen;
+	dbRecordIndex = mp3Info->DbRecIdx;
+	mp3PlayedLen = aud->Mp3PlayedLen;
+	mp3PlayedLen2 = aud->Mp3PlayedLen;
+
+	byte mp3[1024] = { 0 };
+
+	// TODO: read the unknown dword
+	uint32_t unk = *((DWORD*)(&aud->SourceInfo->field_10));
+	lenNeeded = lenNeeded2 = (unk * channelCount * bitDepth) / 8;	// samplecount
+
+	size_t pcmSize;
+	switch (bitDepth + channelCount)
+	{
+	case 0x11:
+		pcmSize = 1018 * 4 + 2;
+		break;
+	case 0x12:
+		pcmSize = 1018 * 4 + 4;
+		break;
+	default:
+		printf("The input format is unsupported.\n");
+		return;
+	}
+	byte* pcm = pcm2 = (byte*)malloc(pcmSize);
+	pcmLen = playedLen = playedLen2 = pcmSize;
+	uint32_t inputCur = 0;
+
+	while (1)
+	{
+		if (playedLen < pcmLen)
+		{
+			lenToCpy = pcmLen - playedLen;
+			if (pcmLen - playedLen >= lenNeeded)
+				lenToCpy = lenNeeded;
+			memcpy(out + dstCur, pcm2 + playedLen, lenToCpy);
+			dstCur += lenToCpy;
+			lenNeeded = lenNeeded2 - lenToCpy;
+			playedLen = lenToCpy + playedLen2;
+			mp3PlayedLen = mp3PlayedLen2;
+			lenNeeded2 = lenNeeded;
+		}
+		if (!lenNeeded)
+			break;
+		lenToRead = 1024;
+		if (mp3PlayedLen + 1024 > mp3DataLen)
+			lenToRead = mp3DataLen - mp3PlayedLen;
+		inputCur = mp3PlayedLen;
+		memcpy(mp3, input + inputCur, lenToRead);
+		readedLen = lenToRead;
+		firstShort2 = ((uint16_t*)mp3)[0];
+		secondShort = ((uint16_t*)mp3)[1];
+		fifthByte = mp3[4];
+		sixthByte = mp3[5];
+		mp3ByteCur = mp3 + 6;
+		firstShort = firstShort2;
+		v77 = fifthByte;
+		switch (bitDepth + channelCount)
+		{
+		case 0x11:
+			*(_WORD*)pcm2 = firstShort2;
+			v29 = (WORD*)(pcm2 + 2);
+			pcmShortCurb = 1018;
+			break;
+		case 0x12:
+			*(_WORD*)pcm2 = firstShort2;
+			pcmShortCura = 1018;
+			*((_WORD*)pcm2 + 1) = secondShort;
+			v18 = (WORD*)(pcm2 + 4);
+			while (1)
+			{
+				v68 = *mp3ByteCur >> 4;
+				v52 = g_AudDecodeData2[2 * fifthByte];
+				v19 = 0;
+				if (v68 & 4)
+					v19 = v52;
+				if (v68 & 2)
+					v19 += (signed int)v52 >> 1;
+				if (v68 & 1)
+					v19 += (signed int)v52 >> 2;
+				v20 = ((signed int)v52 >> 3) + v19;
+				if (v68 & 8)
+					v20 = -v20;
+				v21 = (signed __int16)firstShort + v20;
+				if (v21 <= 0x7FFF)
+				{
+					if (v21 < -32768)
+						LOWORD(v21) = -32768;
+				}
+				else
+				{
+					LOWORD(v21) = 0x7FFF;
+				}
+				LOWORD(firstShort) = v21;
+				v22 = (char)(g_AudDecodeData1[4 * v68] + v77) < 0;
+				v23 = g_AudDecodeData1[4 * v68] + v77;
+				v77 += g_AudDecodeData1[4 * v68];
+				if (v22)
+				{
+					v77 = 0;
+				}
+				else if (v23 > 88)
+				{
+					v77 = 88;
+				}
+				*v18 = firstShort;
+				v24 = v18 + 1;
+				v69 = *mp3ByteCur++ & 0xF;
+				v25 = 0;
+				if (v69 & 4)
+					v25 = (unsigned __int16)g_AudDecodeData2[2 * (char)sixthByte];
+				if (v69 & 2)
+					v25 += (signed int)(unsigned __int16)g_AudDecodeData2[2 * (char)sixthByte] >> 1;
+				if (v69 & 1)
+					v25 += (signed int)(unsigned __int16)g_AudDecodeData2[2 * (char)sixthByte] >> 2;
+				v26 = ((signed int)(unsigned __int16)g_AudDecodeData2[2 * (char)sixthByte] >> 3) + v25;
+				if (v69 & 8)
+					v26 = -v26;
+				v27 = (signed __int16)secondShort + v26;
+				if (v27 <= 0x7FFF)
+				{
+					if (v27 < -32768)
+						LOWORD(v27) = -32768;
+				}
+				else
+				{
+					LOWORD(v27) = 0x7FFF;
+				}
+				LOWORD(secondShort) = v27;
+				v22 = (char)(g_AudDecodeData1[4 * v69] + sixthByte) < 0;
+				v28 = g_AudDecodeData1[4 * v69] + sixthByte;
+				sixthByte += g_AudDecodeData1[4 * v69];
+				if (v22)
+				{
+					sixthByte = 0;
+				}
+				else if (v28 > 88)
+				{
+					sixthByte = 88;
+				}
+				*v24 = secondShort;
+				v18 = v24 + 1;
+				if (!--pcmShortCura)
+					break;
+				fifthByte = v77;
+			}
+			goto LABEL_132;
+		}
+		do
+		{
+			v70 = *mp3ByteCur >> 4;
+			v30 = g_AudDecodeData2[2 * fifthByte];
+			v31 = 0;
+			if (v70 & 4)
+				v31 = v30;
+			if (v70 & 2)
+				v31 += (signed int)v30 >> 1;
+			if (v70 & 1)
+				v31 += (signed int)v30 >> 2;
+			v32 = ((signed int)v30 >> 3) + v31;
+			if (v70 & 8)
+				v32 = -v32;
+			v33 = (signed __int16)firstShort + v32;
+			if (v33 <= 0x7FFF)
+			{
+				if (v33 < -32768)
+					LOWORD(v33) = -32768;
+			}
+			else
+			{
+				LOWORD(v33) = 0x7FFF;
+			}
+			LOWORD(firstShort) = v33;
+			v22 = (char)(g_AudDecodeData1[4 * v70] + v77) < 0;
+			v34 = g_AudDecodeData1[4 * v70] + v77;
+			v77 += g_AudDecodeData1[4 * v70];
+			if (v22)
+			{
+				v34 = 0;
+			}
+			else
+			{
+				if (v34 <= 88)
+					goto LABEL_66;
+				v34 = 88;
+			}
+			v77 = v34;
+		LABEL_66:
+			*v29 = firstShort;
+			v35 = v29 + 1;
+			v71 = *mp3ByteCur++ & 0xF;
+			v53 = g_AudDecodeData2[2 * v34];
+			v36 = 0;
+			if (v71 & 4)
+				v36 = v53;
+			if (v71 & 2)
+				v36 += (signed int)v53 >> 1;
+			if (v71 & 1)
+				v36 += (signed int)v53 >> 2;
+			v37 = ((signed int)v53 >> 3) + v36;
+			if (v71 & 8)
+				v37 = -v37;
+			v38 = (signed __int16)firstShort + v37;
+			if (v38 <= 0x7FFF)
+			{
+				if (v38 < -32768)
+					LOWORD(v38) = -32768;
+			}
+			else
+			{
+				LOWORD(v38) = 0x7FFF;
+			}
+			LOWORD(firstShort) = v38;
+			v22 = (char)(g_AudDecodeData1[4 * v71] + v77) < 0;
+			fifthByte = g_AudDecodeData1[4 * v71] + v77;
+			v77 += g_AudDecodeData1[4 * v71];
+			if (v22)
+			{
+				fifthByte = 0;
+			}
+			else
+			{
+				if (fifthByte <= 88)
+					goto LABEL_83;
+				fifthByte = 88;
+			}
+			v77 = fifthByte;
+		LABEL_83:
+			*v35 = firstShort;
+			v29 = v35 + 1;
+			--pcmShortCurb;
+		} while (pcmShortCurb);
+	LABEL_132:
+		mp3PlayedLen2 += readedLen;
+		playedLen = 0;
+		playedLen2 = 0;
+		if (!readedLen)
+		{
+			result = aud;
+			aud->PcmPlayedLen = 0;
+			aud->Mp3PlayedLen = mp3PlayedLen2;
+			free(pcm);
+			return;
+		}
+		lenNeeded = lenNeeded2;
+		result = aud;
+		pcmLen = pcmLen;
+		mp3PlayedLen = mp3PlayedLen2;
+		pcm2 = pcm;
+	}
+	result->PcmPlayedLen = playedLen;
+	result->Mp3PlayedLen = mp3PlayedLen;
+	free(pcm);
+}

--- a/Septerra.AudioConverter/Septerra.AudioConverter.cpp
+++ b/Septerra.AudioConverter/Septerra.AudioConverter.cpp
@@ -1,0 +1,207 @@
+﻿#include <fstream>
+#include <iostream>
+#include <filesystem>
+#include "Dsound.h"
+#include "Decoder.hpp"
+
+using namespace std;
+namespace fs = std::filesystem;
+
+struct PathInfo
+{
+	string Directory;
+	string FileName;
+	string FileNameWithoutExtension;
+};
+
+PathInfo GetPathInfo(fs::path path)
+{
+	PathInfo info = {};
+	string str = path.string();
+	int i = str.rfind('\\');	// Windows sep
+	if (i == string::npos)
+	{
+		i = str.rfind('/');	// Unix sep
+	}
+	if (i == string::npos)
+	{
+		i = -1;
+	}
+
+	info.Directory = str.substr(0, i + 1);
+	info.FileName = str.substr(i + 1, str.length() - i);
+
+	int j = str.rfind('.');
+	if (j == string::npos)
+	{
+		j = str.length();
+	}
+	info.FileNameWithoutExtension = str.substr(i + 1, j - i - 1);
+
+	return info;
+}
+
+void convert(fs::path file)
+{
+	// Check file
+	ifstream mp3(file, ios::binary | ios::ate);
+	if (!mp3.good())
+	{
+		cout << "Can't open the specified MP3." << endl;
+		return;
+	}
+
+	int len = mp3.tellg();
+	mp3.seekg(0, mp3.beg);
+	if (len < sizeof(Mp3Header))
+	{
+		cout << "The specified MP3 is too short to be valid." << endl;
+		return;
+	}
+
+	// Check VSSF header
+	uint32_t tmp = 0;
+	mp3.read((char*)&tmp, sizeof(uint32_t));
+	if (tmp != 0x46535356)
+	{
+		mp3.seekg(0, mp3.beg);
+	}
+	else
+	{
+		cout << "Found VSSF header." << endl;
+	}
+
+	Mp3Header hdr{};
+	mp3.read((char*)&hdr, sizeof(Mp3Header));
+
+	// Check type
+	if (hdr.Type == 0x0003)
+	{
+		cout << "The specified MP3 is a dialogue and can be opened directly." << endl;
+		return;
+	}
+	uint8_t flag = hdr.BitDepth + hdr.ChannelCount;
+	if (flag != 0x11 && flag != 0x12)
+	{
+		cout << "The specified MP3 has an unsupported bit depth/channel count." << endl;
+		return;
+	}
+
+	// Print info
+	PathInfo info = GetPathInfo(file);
+	cout << "File: " << info.FileName
+		<< ", " << +hdr.BitDepth << "-bit " << hdr.SampleRate << " hz, "
+		<< +hdr.ChannelCount << " channel(s), "
+		<< hdr.SampleCount << " samples" << endl;
+
+	// Create input struct
+	uint32_t pcmLen = hdr.SampleCount * hdr.ChannelCount * hdr.BitDepth / 8;
+	uint32_t mp3Len = len - (int)mp3.tellg();
+
+	struct_v12 v12 = {};
+	v12.BitDepth = hdr.BitDepth;
+	v12.Channels = hdr.ChannelCount;
+	v12.SampleRate = hdr.SampleRate;
+
+	source_info si = {};
+	si.BitDepth = hdr.BitDepth;
+	si.ChannelCount = hdr.ChannelCount;
+	si.DataLen = mp3Len;
+	si.field_10 = hdr.SampleCount;
+	si.SampleRate = hdr.SampleRate;
+	si.TotalPcmLen = pcmLen;
+
+	sound s = {};
+	s.dword4 = &v12;
+	s.SourceInfo = &si;
+
+	// Create output buffer
+	char* input = (char*)malloc(mp3Len);
+	char* output = (char*)malloc(pcmLen);
+	mp3.read((char*)input, mp3Len);
+	Decode(&s, output, pcmLen, input);
+
+	// Create output file
+	string wavPath = info.Directory + "converted_" + info.FileNameWithoutExtension + ".wav";
+	ofstream out(wavPath, ios::binary);
+
+	// Make WAV header
+	// https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ee419050(v=vs.85)
+	WAVEFORMATEX wav{};
+	wav.wFormatTag = WAVE_FORMAT_PCM;
+	wav.nSamplesPerSec = hdr.SampleRate;
+	wav.wBitsPerSample = hdr.BitDepth;
+	wav.nChannels = hdr.ChannelCount;
+	wav.nBlockAlign =
+		wav.nChannels * (wav.wBitsPerSample / 8);
+	wav.nAvgBytesPerSec =
+		wav.nBlockAlign * wav.nSamplesPerSec;
+
+	// Write file
+	uint32_t wavLen = sizeof(wav);
+	// data, data length, data tag, format, format length, format tag, WAVE tag
+	uint32_t riffLen = pcmLen + 4 + 4 + wavLen + 4 + 4 + 4;
+	out.write("RIFF", 4);
+	out.write((char*)&riffLen, sizeof(uint32_t));
+	out.write("WAVEfmt ", 8);
+	out.write((char*)&wavLen, sizeof(uint32_t));
+	out.write((char*)&wav, wavLen);
+	out.write("data", 4);
+	out.write((char*)&pcmLen, sizeof(uint32_t));
+	out.write(output, pcmLen);
+	cout << "Dumped sfx/mus " << wavPath << ", " << pcmLen << " bytes of samples" << endl;
+
+	out.close();
+	mp3.close();
+}
+
+int main(int argc, char* argv[])
+{
+	// Sanity checks
+	if (argc < 2)
+	{
+		cout << "Usage: Septerra.AudioConverter.exe [path]" << endl;
+		cout << "Path can be either a single MP3 file or a folder of MP3s." << endl;
+		system("pause");
+		return 1;
+	}
+
+	if (!fs::exists(argv[1]))
+	{
+		cout << "Error: the specified file or directory doesn't exist." << endl;
+		return 1;
+	}
+
+	if (fs::is_regular_file(argv[1]))
+	{
+		// Convert a single file
+		cout << "Converting " << argv[1] << endl;
+		convert(argv[1]);
+	}
+	else if (fs::is_directory(argv[1]))
+	{
+		// Convert all files under directory
+		cout << "Input directory: " << argv[1] << endl;
+		auto iter = fs::directory_iterator(argv[1]);
+		for (auto& entry : iter)
+		{
+			if (entry.is_regular_file() && entry.path().extension() == ".mp3")
+			{
+				cout << "Converting " << entry.path() << endl;
+				convert(entry.path());
+			}
+			else
+			{
+				cout << "Skipping " << entry.path() << " (not MP3 file)" << endl;
+			}
+		}
+	}
+	else
+	{
+		cout << "Error: input is neither a file nor a directory, what is it?" << endl;
+		return 1;
+	}
+
+	cout << "Done." << endl;
+	return 0;
+}

--- a/Septerra.AudioConverter/Septerra.AudioConverter.vcxproj
+++ b/Septerra.AudioConverter/Septerra.AudioConverter.vcxproj
@@ -21,14 +21,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>false</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>false</CLRSupport>

--- a/Septerra.AudioConverter/Septerra.AudioConverter.vcxproj
+++ b/Septerra.AudioConverter/Septerra.AudioConverter.vcxproj
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{f2a5b759-9a15-4456-83bc-3562bf71c80e}</ProjectGuid>
+    <RootNamespace>SepterraAudioConverter</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <CLRSupport>false</CLRSupport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+    <CLRSupport>false</CLRSupport>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)Output\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Septerra.AudioConverter.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Decoder.hpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Septerra.AudioConverter/Septerra.AudioConverter.vcxproj.filters
+++ b/Septerra.AudioConverter/Septerra.AudioConverter.vcxproj.filters
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="源文件">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="头文件">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="资源文件">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Septerra.AudioConverter.cpp">
+      <Filter>源文件</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Decoder.hpp">
+      <Filter>头文件</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/Septerra.Injection/Hooks/DllMain.cpp
+++ b/Septerra.Injection/Hooks/DllMain.cpp
@@ -17,6 +17,8 @@
 #include "Septerra_TxRecord_FindString.hpp"
 #include "Septerra_DispatchBattle.hpp"
 
+#include "Septerra_Audio_Decode.hpp"
+
 #pragma comment(lib, "detours.lib")
 #pragma unmanaged
 
@@ -43,6 +45,8 @@ namespace SepterraInjection
 		Hook(Septerra_TxRecord_ReleaseByPointer);
 		Hook(Septerra_TxRecord_ReleaseByResourceId);
 		Hook(Septerra_DispatchBattle);
+
+		Hook(Septerra_Audio_Decode);
 
 		/*Hook(Septerra_TxRecord_FindString);*/
 

--- a/Septerra.Injection/Hooks/Septerra_Audio_Decode.hpp
+++ b/Septerra.Injection/Hooks/Septerra_Audio_Decode.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+// ReSharper disable CppCStyleCast
+
+#include "Dsound.h"
+
+using namespace Septerra::Core;
+
+namespace SepterraInjection
+{
+	/**
+	 * Structs here are incomplete,
+	 * for complete structs see
+	 * Septerra.AudioConverter
+	 */
+
+	/* 194 */
+	struct __declspec(align(2)) struct_v12
+	{
+		BYTE gap0[16];
+		WORD SampleRate;
+		BYTE Channels;
+		BYTE BitDepth;
+	};
+
+	/* 201 */
+	struct __declspec(align(4)) source_info
+	{
+		source_info* unk;
+		DWORD DbRecIdx;
+		DWORD TotalPcmLen;
+		DWORD Pcm;
+		char field_10[28];
+		DWORD DataLen;
+		DWORD Format;
+		DWORD field_34;
+		short SampleRate;
+		BYTE ChannelCount;
+		BYTE BitDepth;
+	};
+
+	/* 192 */
+	struct __declspec(align(4)) sound
+	{
+		sound* next;
+		struct_v12* dword4;
+		DWORD dword8;
+		source_info* SourceInfo;
+		uint32_t dword10;
+		unsigned char* Mp3ReadBuf;
+		uint32_t Mp3PlayedLen;
+	};
+
+	typedef int(__cdecl* Septerra_Audio_Decode)(sound* sound, Byte* out, UInt32 lenNeeded);
+
+	Septerra_Audio_Decode O_Septerra_Audio_Decode = (Septerra_Audio_Decode)0x468540;
+
+	Septerra_Audio_Decode O_Septerra_Audio_Decode_MP2 = (Septerra_Audio_Decode)0x468D60;
+
+	int __cdecl Hook_Decode(sound* sound, Byte* out, UInt32 lenNeeded)
+	{
+		if (!sound->Mp3PlayedLen)
+		{
+			// Only log on first decoder call
+			char msg[128];
+			snprintf(msg, sizeof(msg),
+				"Beginning decode of mus/sfx record ID 0x%08x: %d-bit, %d channel(s), %d Hz, %d PCM bytes",
+				sound->SourceInfo->DbRecIdx, sound->SourceInfo->BitDepth,
+				sound->SourceInfo->ChannelCount, sound->SourceInfo->SampleRate,
+				sound->SourceInfo->TotalPcmLen);
+			Log::Message(gcnew String(msg));
+		}
+		return O_Septerra_Audio_Decode(sound, out, lenNeeded);
+	}
+
+	Septerra_Audio_Decode H_Septerra_Audio_Decode = Hook_Decode;
+}

--- a/Septerra.Injection/Septerra.Injection.vcxproj
+++ b/Septerra.Injection/Septerra.Injection.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{DFB119CA-5408-46F3-9323-0BADDDDCA0A7}</ProjectGuid>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>SepterraInjection</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
@@ -22,14 +22,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Septerra.Injection/Septerra.Injection.vcxproj
+++ b/Septerra.Injection/Septerra.Injection.vcxproj
@@ -120,6 +120,7 @@
   <ItemGroup>
     <ClInclude Include="CLR\AssemblyResolver.hpp" />
     <ClInclude Include="Debugger\Debugger.h" />
+    <ClInclude Include="Hooks\Septerra_Audio_Decode.hpp" />
     <ClInclude Include="Hooks\Septerra_TxRecord_FindString.hpp" />
     <ClInclude Include="Hooks\Septerra_TxRecord_ReleaseByResourceId.hpp" />
     <ClInclude Include="Hooks\Septerra_TxRecord_Find.hpp" />

--- a/Septerra.Native/Septerra.Native.vcxproj
+++ b/Septerra.Native/Septerra.Native.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{7F86FF0F-8D61-439B-BAE4-79456EA34053}</ProjectGuid>
-    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>SepterraNative</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
@@ -22,14 +22,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Septerra.sln
+++ b/Septerra.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27705.2000
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Septerra.Native", "Septerra.Native\Septerra.Native.vcxproj", "{7F86FF0F-8D61-439B-BAE4-79456EA34053}"
 EndProject
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Septerra.AudioConverter", "Septerra.AudioConverter\Septerra.AudioConverter.vcxproj", "{F2A5B759-9A15-4456-83BC-3562BF71C80E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,12 @@ Global
 		{B18B8E4F-F0A2-4825-B83F-7D0EEC2912D2}.Release|Any CPU.ActiveCfg = Release|x86
 		{B18B8E4F-F0A2-4825-B83F-7D0EEC2912D2}.Release|x86.ActiveCfg = Release|x86
 		{B18B8E4F-F0A2-4825-B83F-7D0EEC2912D2}.Release|x86.Build.0 = Release|x86
+		{F2A5B759-9A15-4456-83BC-3562BF71C80E}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{F2A5B759-9A15-4456-83BC-3562BF71C80E}.Debug|x86.ActiveCfg = Debug|Win32
+		{F2A5B759-9A15-4456-83BC-3562BF71C80E}.Debug|x86.Build.0 = Debug|Win32
+		{F2A5B759-9A15-4456-83BC-3562BF71C80E}.Release|Any CPU.ActiveCfg = Release|Win32
+		{F2A5B759-9A15-4456-83BC-3562BF71C80E}.Release|x86.ActiveCfg = Release|Win32
+		{F2A5B759-9A15-4456-83BC-3562BF71C80E}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a hook for the music/sfx MP3 decoder subroutine that logs some info about the audio being decoded. Also adds a standalone decoder project that converts extracted music/sfx MP3s to WAV PCM, using code decompiled from the decoder subroutine.

Addresses #3.